### PR TITLE
install rasterio through conda

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,6 +8,7 @@ dependencies:
   - pysal
   - folium
   - scikit-learn
+  - rasterio
   - pip
   - pip:
     - contextily


### PR DESCRIPTION
this works to resolve #9. 

Locally, I still get errors on `mkl-fft` and `mkl-random`, but this at least allows for installation of contextliy. 

not sure where the mkls are getting pulled in... though it appears immediately `pyparsing` is installed through pip, required by `snuggs`, required by `rasterio`. 