### PR TITLE
Change kernel of case-gini notebook from gds to Python 3

### DIFF
--- a/_solved/case-gini-in-a-bottle-the-trump-vote.ipynb
+++ b/_solved/case-gini-in-a-bottle-the-trump-vote.ipynb
@@ -895,9 +895,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "gds",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "gds"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/case-gini-in-a-bottle-the-trump-vote.ipynb
+++ b/case-gini-in-a-bottle-the-trump-vote.ipynb
@@ -314,9 +314,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "gds",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "gds"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
All the other notebooks don't use gds as kernel name (and also if you install the notebook in your environment for the tutorial, this should be Python 3)