### PR TITLE
redo environment

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,14 +1,16 @@
 name: scipygeo18
 channels:
-  - defaults
   - conda-forge
 dependencies:
+  - python=3.7
   - geopandas
   - geoplot
   - pysal
   - folium
   - scikit-learn
   - rasterio
+  - jupyterlab
+  - pytest
   - pip
   - pip:
     - contextily


### PR DESCRIPTION
I wasn't able to get the environment working as it is in the repo. This was on Windows 10. Having everything come from conda-forge seems to fix all sorts of dependency circles, and specifying a python version also helped. I've now tested my updated environment.yml on Windows 10 and Ubuntu 18.04. In both cases the check_environment script ran and I was able to work through the tutorial.